### PR TITLE
Backup and restore did not include alternative hosts and some other meeting settings

### DIFF
--- a/backup/moodle2/backup_zoom_stepslib.php
+++ b/backup/moodle2/backup_zoom_stepslib.php
@@ -42,12 +42,12 @@ class backup_zoom_activity_structure_step extends backup_activity_structure_step
     protected function define_structure() {
         // Define the root element describing the zoom instance.
         $zoom = new backup_nested_element('zoom', array('id'), array(
-            'intro', 'introformat', 'grade',
-            'uuid', 'meeting_id', 'start_url', 'join_url',
-            'created_at', 'host_id', 'name', 'start_time', 'timemodified',
-            'recurring', 'webinar', 'duration', 'timezone', 'password', 'option_encryption_type', 'option_jbh',
-            'option_start_type', 'option_host_video', 'option_participants_video',
-            'option_audio', 'status'));
+                'intro', 'introformat', 'grade', 'meeting_id', 'start_url', 'join_url', 'created_at', 'host_id', 'name',
+                'start_time', 'timemodified', 'recurring', 'webinar', 'duration', 'timezone', 'password', 'option_jbh',
+                'option_start_type', 'option_host_video', 'option_participants_video', 'option_audio', 'option_mute_upon_entry',
+                'option_waiting_room', 'option_authenticated_users', 'option_encryption_type', 'exists_on_zoom',
+                'alternative_hosts')
+        );
 
         // If we had more elements, we would build the tree here.
 

--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -70,7 +70,7 @@ class restore_zoom_activity_structure_step extends restore_activity_structure_st
         $updateddata = $service->create_meeting($data);
         if (!$updateddata) {
             $updateddata = new stdClass;
-            $updateddata->status = ZOOM_MEETING_EXPIRED;
+            $updateddata->exists_on_zoom = ZOOM_MEETING_EXPIRED;
         }
 
         $data->start_url = $updateddata->start_url;

--- a/classes/external.php
+++ b/classes/external.php
@@ -104,7 +104,7 @@ class mod_zoom_external extends external_api {
         $result['audioopt'] = $zoom->option_audio;
 
         if (!$zoom->recurring) {
-            if (!$zoom->exists_on_zoom) {
+            if ($zoom->exists_on_zoom == ZOOM_MEETING_EXPIRED) {
                 $status = get_string('meeting_nonexistent_on_zoom', 'mod_zoom');
             } else if ($finished) {
                 $status = get_string('meeting_finished', 'mod_zoom');

--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -75,7 +75,7 @@ class update_meetings extends \core\task\scheduled_task {
         $service = new \mod_zoom_webservice();
 
         // Check all meetings, in case they were deleted/changed on Zoom.
-        $zoomstoupdate = $DB->get_records('zoom', array('exists_on_zoom' => true));
+        $zoomstoupdate = $DB->get_records('zoom', array('exists_on_zoom' => ZOOM_MEETING_EXISTS));
         $courseidstoupdate = array();
         $calendarfields = array('intro', 'introformat', 'start_time', 'duration', 'recurring');
 
@@ -86,7 +86,7 @@ class update_meetings extends \core\task\scheduled_task {
                 $gotinfo = true;
             } catch (\moodle_exception $error) {
                 // Outputs error and then goes to next meeting.
-                $zoom->exists_on_zoom = false;
+                $zoom->exists_on_zoom = ZOOM_MEETING_EXPIRED;
                 $DB->update_record('zoom', $zoom);
                 mtrace('Error updating Zoom meeting with meeting_id ' . $zoom->meeting_id . ': ' . $error);
             }

--- a/lib.php
+++ b/lib.php
@@ -247,7 +247,7 @@ function zoom_delete_instance($id) {
     require_once($CFG->dirroot.'/mod/zoom/locallib.php');
 
     // If the meeting is missing from zoom, don't bother with the webservice.
-    if ($zoom->exists_on_zoom) {
+    if ($zoom->exists_on_zoom == ZOOM_MEETING_EXISTS) {
         $service = new mod_zoom_webservice();
         try {
             $service->delete_meeting($zoom->meeting_id, $zoom->webinar);

--- a/locallib.php
+++ b/locallib.php
@@ -42,6 +42,10 @@ define('ZOOM_SCHEDULED_MEETING', 2);
 define('ZOOM_RECURRING_MEETING', 3);
 define('ZOOM_SCHEDULED_WEBINAR', 5);
 define('ZOOM_RECURRING_WEBINAR', 6);
+// Meeting status.
+define('ZOOM_MEETING_EXPIRED', 0);
+define('ZOOM_MEETING_EXISTS', 1);
+
 // Number of meetings per page from zoom's get user report.
 define('ZOOM_DEFAULT_RECORDS_PER_CALL', 30);
 define('ZOOM_MAX_RECORDS_PER_CALL', 300);

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -55,7 +55,7 @@ class mod_zoom_generator extends testing_module_generator {
             'option_mute_upon_entry' => 0,
             'start_time' => mktime(0, 0, 0, 2, 22, 2021),
             'duration' => 60,
-            'exists_on_zoom' => 0,
+            'exists_on_zoom' => ZOOM_MEETING_EXPIRED,
         );
 
         $record = (object) (array) $record;

--- a/tests/get_meeting_reports_test.php
+++ b/tests/get_meeting_reports_test.php
@@ -312,7 +312,7 @@ class get_meeting_reports_test extends advanced_testcase {
         // Insert stub data for zoom table.
         $DB->insert_record('zoom', ['course' => $SITE->id,
                 'meeting_id' => $meeting->id, 'name' => 'Zoom',
-                'exists_on_zoom' => 1]);
+                'exists_on_zoom' => ZOOM_MEETING_EXISTS]);
 
         // Run task process_meeting_reports() and should insert participants.
         $this->meetingtask->service = $mockwwebservice;

--- a/view.php
+++ b/view.php
@@ -240,7 +240,7 @@ if ($config->showdownloadical != ZOOM_DOWNLOADICAL_DISABLE && (!($showrecreate |
 
 // Show meeting status.
 if (!$zoom->recurring) {
-    if (!$zoom->exists_on_zoom) {
+    if ($zoom->exists_on_zoom == ZOOM_MEETING_EXPIRED) {
         $status = get_string('meeting_nonexistent_on_zoom', 'mod_zoom');
     } else if ($finished) {
         $status = get_string('meeting_finished', 'mod_zoom');


### PR DESCRIPTION
This patch fixes the bug that alternative hosts and the meeting options mute_upon_entry, waiting_room and authenticated_users were not handled during backup