### PR TITLE
Check if a Zoom account is active before offering it as alternative host

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -582,8 +582,10 @@ function zoom_get_selectable_alternative_hosts_list(context $context) {
         // At least, Zoom does not care if the user who is the host adds himself as alternative host as well.
 
         // Verify that the user really has a Zoom account.
+        // Furthermore, verify that the user's status is active. Adding a pending or inactive user as alternative host will result
+        // in a Zoom API error otherwise.
         $zoomuser = $service->get_user($u->email);
-        if ($zoomuser !== false) {
+        if ($zoomuser !== false && $zoomuser->status === 'active') {
             // Add user to array of users.
             $selectablealternativehosts[$u->email] = fullname($u);
         }


### PR DESCRIPTION
This patch fixes a flaw which existed before when the list of alternative hosts was composed for the alternative hosts user picker.
Adding a pending or inactive user as alternative host will result in a Zoom API error, that's why we check if the user is active before offering it as alternative host.